### PR TITLE
Support cases where entry is null

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ export class Walker<T extends InputSchema = InputSchema> {
 
   private cleanupVisited = (schema: ISubSchema) => {
     for (const entry of Object.values(schema)) {
-      if (typeof entry === "object" && entry[visited]) {
+      if (typeof entry === "object" && null !== entry && entry[visited]) {
         delete entry[visited];
         this.cleanupVisited(entry);
       }


### PR DESCRIPTION
An error is raised when `entry === null`. This can happen, for example, when the `default` value of a type is set to `null`.

This patch just ensures `entry` is non-null before attempting to access the `visited` symbol on it.