### PR TITLE
feat(sync): Add sync methods for walker

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,25 @@ Passing the options
 ```
 
 will dereference all non-circular references in your schema.
+
+## Synchronous API
+
+For cases where you don't need `$ref` resolution, you can use the synchronous methods:
+
+```typescript
+import { Walker } from "json-schema-walker";
+const schema = {
+  // your json schema (without $ref)
+};
+const walker = new Walker<T>();
+walker.loadSchemaSync(schema, {
+  cloneSchema: true, // only option available
+});
+const convertSchema = (schema) => {
+  // do something with the schema properties
+};
+walker.walkSync(convertSchema, walker.vocabularies.DRAFT_07);
+const updatedSchema = walker.rootSchema;
+```
+
+> ⚠️ **Warning**: The synchronous methods (`loadSchemaSync` and `walkSync`) do not support `$ref` resolution. Use the async methods if your schema contains references.


### PR DESCRIPTION

This pr adds two methods to `Walker` class


1. `loadSchemaSync` and `walkSync` 

I would like this these two methods so that I can add support for `convertSync` method in [https://github.com/openapi-contrib/json-schema-to-openapi-schema](json-schema-to-openapi-schema) project. 


I have updated the README.md with examples of these two methods. 

Also I noticed the existing `walk` function does not need to be `async` but I am assuming you have kept it `async` for a reason therefore I have created new function `walkSync`



